### PR TITLE
fixed bug with citations not being made

### DIFF
--- a/src/Plugin/CitationFieldFormatter/EdtfDateFormatter.php
+++ b/src/Plugin/CitationFieldFormatter/EdtfDateFormatter.php
@@ -24,13 +24,8 @@ class EdtfDateFormatter extends CitationFieldFormatterBase {
 
     // The parser may return either an EDTF Set or an ExtDate object.
     if (method_exists($edtf_value, 'getDates')) {
-      // Parser returned a Set.
-      $edtf_dates = $edtf_value = $edtf_value->getDates();
-      $date_parts = [
-        $edtf_dates[0]->getYear(),
-        $edtf_dates[0]->getMonth(),
-        $edtf_dates[0]->getDay(),
-      ];
+      // Parser returned a Set, return no date.
+      $date_parts = [];
     }
     else {
       // Parser returned an ExtDate object.

--- a/src/Plugin/CitationFieldFormatter/EdtfDateFormatter.php
+++ b/src/Plugin/CitationFieldFormatter/EdtfDateFormatter.php
@@ -21,11 +21,25 @@ class EdtfDateFormatter extends CitationFieldFormatterBase {
   protected function parseDate($string) {
     $parser = EdtfFactory::newParser();
     $edtf_value = $parser->parse($string)->getEdtfValue();
-    $date_parts = [
-      $edtf_value->getYear(),
-      $edtf_value->getMonth(),
-      $edtf_value->getDay(),
-    ];
+
+    // The parser may return either an EDTF Set or an ExtDate object.
+    if (method_exists($edtf_value, 'getDates')) {
+      // Parser returned a Set.
+      $edtf_dates = $edtf_value = $edtf_value->getDates();
+      $date_parts = [
+        $edtf_dates[0]->getYear(),
+        $edtf_dates[0]->getMonth(),
+        $edtf_dates[0]->getDay(),
+      ];
+    }
+    else {
+      // Parser returned an ExtDate object.
+      $date_parts = [
+        $edtf_value->getYear(),
+        $edtf_value->getMonth(),
+        $edtf_value->getDay(),
+      ];
+    }
 
     return [
       'date-parts' => [$date_parts],


### PR DESCRIPTION
The bug occurred due to the parser function returning an EDTF value with multiple dates rather than one date, so calling `$edtf_value->getYear()` would then be an undefined call,  `$edtf_value->getDates()`had to be called to get the dates first.