### PR TITLE
Picks up first publisher instead of last

### DIFF
--- a/src/Plugin/CitationFieldFormatter/TypedRelationFormatter.php
+++ b/src/Plugin/CitationFieldFormatter/TypedRelationFormatter.php
@@ -94,6 +94,9 @@ class TypedRelationFormatter extends CitationFieldFormatterBase implements Conta
             break;
 
           default:
+            if ($rel_name == "publisher" && isset($data[$rel_name])) {
+              break;
+            }
             $data[$rel_name] = $value;
             break;
         }


### PR DESCRIPTION
# Issue
- Multiple publishers causes publisher entry being overridden which results in the last publisher being picked up instead of the first

# Solution
- If statement set to prevent overriding the first publisher