### PR TITLE
Added support for citing objects with Interval or Set EDTF dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,9 @@ Download module using Composer, and enable with Drush.
 2. Configure the Citation Select CSL Mapping to map node fields to CSL fields.
 3. Install some CSL styles.
 4. Use the Citation Select block on the node's page to choose a citation style. The formatted citation will appear below the block and can be copied with the "Copy citation" button.
+
+### Note ###
+If using EDTF dates as a field for citation processing beware of the following:
+- Citation Select processor is unable to handle open interval dates (i.e [..2003] or ../2003)
+  - Citation Select will ignore these types of date sets or intervals and cite as if the dates do not exist
+- Citation Select allows for closed date sets and closed interval dates along with single dates (i.e [1999-01..2003-02] or 1999/2003 or 2003-02-01) 

--- a/src/Plugin/CitationFieldFormatter/EdtfDateFormatter.php
+++ b/src/Plugin/CitationFieldFormatter/EdtfDateFormatter.php
@@ -21,24 +21,74 @@ class EdtfDateFormatter extends CitationFieldFormatterBase {
   protected function parseDate($string) {
     $parser = EdtfFactory::newParser();
     $edtf_value = $parser->parse($string)->getEdtfValue();
-
-    // The parser may return either an EDTF Set or an ExtDate object.
-    if (method_exists($edtf_value, 'getDates')) {
-      // Parser returned a Set, return no date.
-      $date_parts = [];
-    }
-    else {
-      // Parser returned an ExtDate object.
-      $date_parts = [
-        $edtf_value->getYear(),
-        $edtf_value->getMonth(),
-        $edtf_value->getDay(),
+    try {
+      // The parser may return either an EDTF Set or an ExtDate object.
+      if (method_exists($edtf_value, 'getStartDate') && method_exists($edtf_value, 'getEndDate')) {
+        // Parser returned an interval.
+        $startDate = $edtf_value->getStartDate();
+        $endDate = $edtf_value->getEndDate();
+        $start_parts = [
+          $startDate->getYear(),
+          $startDate->getMonth(),
+          $startDate->getDay(),
+        ];
+        $end_parts = [
+          $endDate->getYear(),
+          $endDate->getMonth(),
+          $endDate->getDay(),
+        ];
+        // Filter out empty components before adding it into parts.
+        $date_parts = [
+          array_filter($start_parts),
+          array_filter($end_parts),
+        ];
+      }
+      elseif (method_exists($edtf_value, 'getDates')) {
+        // Parser returned a Set.
+        $date_set = $edtf_value->getElements()[0];
+        if (method_exists($date_set, 'getStart') && method_exists($date_set, 'getEnd')) {
+          $startDate = $date_set->getStart();
+          $endDate = $date_set->getEnd();
+          $start_parts = [
+            $startDate->getYear(),
+            $startDate->getMonth(),
+            $startDate->getDay(),
+          ];
+          $end_parts = [
+            $endDate->getYear(),
+            $endDate->getMonth(),
+            $endDate->getDay(),
+          ];
+          // Filter out empty components before adding it into parts.
+          $date_parts = [
+            array_filter($start_parts),
+            array_filter($end_parts),
+          ];
+        }
+        else {
+          // Parser returned a Set with no start or no end.
+          $date_parts = [];
+        }
+      }
+      else {
+        // Parser returned an ExtDate object.
+        $date_parts = [
+          [
+            $edtf_value->getYear(),
+            $edtf_value->getMonth(),
+            $edtf_value->getDay(),
+          ],
+        ];
+      }
+      return [
+        'date-parts' => [...$date_parts],
       ];
     }
-
-    return [
-      'date-parts' => [$date_parts],
-    ];
+    catch (\RuntimeException $e) {
+      return [
+        'date-parts' => [[]],
+      ];
+    }
   }
 
 }


### PR DESCRIPTION
# Summary of Changes
- Added conditional checks within the EdtfDateFormatter
  - Handles closed Sets and Intervals
     - Retrieves the start and end date for the processor to parse
  - Ignores open Sets and Intervals