### PR TITLE
Missing a backslash in front of Exception, which causes CitationFieldFormatterBase::convertName to throw an error. Fix done by baysaa

### DIFF
--- a/src/CitationFieldFormatterBase.php
+++ b/src/CitationFieldFormatterBase.php
@@ -139,7 +139,7 @@ class CitationFieldFormatterBase extends PluginBase implements CitationFieldForm
       }
       return $name_map;
     }
-    catch (Exception $e) {
+    catch (\Exception $e) {
       return [
         'literal' => $name,
       ];


### PR DESCRIPTION
https://www.drupal.org/project/citation_select/issues/3539823

Link to issue and fix^