### PR TITLE
Dates such as 2024-23 used to give errors when it should be converted to 'Autumn 2024', now it properly converts rather than giving a fatal error with this patch. Fix made by baysaa

### DIFF
--- a/src/Plugin/CitationFieldFormatter/EdtfDateFormatter.php
+++ b/src/Plugin/CitationFieldFormatter/EdtfDateFormatter.php
@@ -70,6 +70,18 @@ class EdtfDateFormatter extends CitationFieldFormatterBase {
           $date_parts = [];
         }
       }
+      elseif (method_exists($edtf_value, 'getStartMonth') && method_exists($edtf_value, 'getEndMonth')) {
+        $date_parts = [
+          array_filter([
+            $edtf_value->getYear(),
+            $edtf_value->getStartMonth(),
+          ]),
+          array_filter([
+            $edtf_value->getYear(),
+            $edtf_value->getEndMonth(),
+          ])
+        ];
+      }
       else {
         // Parser returned an ExtDate object.
         $date_parts = [


### PR DESCRIPTION
https://www.drupal.org/project/citation_select/issues/3547495

Link to issue and fix^