### PR TITLE
feat: make dropdown options in the citation selecter to be translatable

### DIFF
--- a/src/Form/SelectCitationForm.php
+++ b/src/Form/SelectCitationForm.php
@@ -83,7 +83,7 @@ class SelectCitationForm extends FormBase {
     $citation_styler = $this->styler;
     $citation_styles = $citation_styler->getEnabledStyles();
     $csl_options = array_map(function ($cs) {
-      return $cs->label();
+      return $this->t($cs->label());
     }, $citation_styles);
 
     $form['#attached']['library'][] = 'citation_select/citation_select_form';


### PR DESCRIPTION
# What does this PR do?
This PR uses a translation function call ```$this->t()``` to support translation for the dropdown labels in the citation selector.