### PR TITLE
fix: remove deprecation notices by explicitly declaring the variables and updating their names

### DIFF
--- a/tests/src/Kernel/CitationPluginTests.php
+++ b/tests/src/Kernel/CitationPluginTests.php
@@ -39,16 +39,23 @@ class CitationPluginTests extends PluginTestBase {
   /**
    * Default formatter.
    *
-   * @var Drupal\citation_select\Plugin\CitationFieldFormatter\DefaultCitationFieldFormatter
+   * @var \Drupal\citation_select\Plugin\CitationFieldFormatter\DefaultCitationFieldFormatter
    */
   protected $defaultFormatter;
 
   /**
    * Entity reference formatter.
    *
-   * @var Drupal\citation_select\Plugin\CitationFieldFormatter\EntityReferenceFormatter
+   * @var \Drupal\citation_select\Plugin\CitationFieldFormatter\EntityReferenceFormatter
    */
   protected $entityReferenceFormatter;
+
+  /**
+   * The citation processor.
+   * 
+   * @var \Drupal\citation_select\CitationProcessorService
+   */
+  protected $citation_processor;
 
   /**
    * {@inheritdoc}
@@ -142,7 +149,7 @@ class CitationPluginTests extends PluginTestBase {
     $this->container->set('citation_select.human_name_parser', $human_parser_mock);
 
     $this->defaultFormatter = new DefaultCitationFieldFormatter([], 'default', []);
-    $this->entity_formatter = new EntityReferenceFormatter([], 'entity_reference', []);
+    $this->entityReferenceFormatter = new EntityReferenceFormatter([], 'entity_reference', []);
   }
 
   /**
@@ -159,7 +166,7 @@ class CitationPluginTests extends PluginTestBase {
     $node->save();
 
     // One standard.
-    $result = $this->entity_formatter->formatMultiple($node, 'entity_reference_field', ['genre' => 'standard']);
+    $result = $this->entityReferenceFormatter->formatMultiple($node, 'entity_reference_field', ['genre' => 'standard']);
     $this->assertEquals(['genre' => 'John'], $result);
 
     $node = Node::create([
@@ -173,7 +180,7 @@ class CitationPluginTests extends PluginTestBase {
     $node->save();
 
     // Multiple names.
-    $result = $this->entity_formatter->formatMultiple($node, 'entity_reference_field', ['genre' => 'person']);
+    $result = $this->entityReferenceFormatter->formatMultiple($node, 'entity_reference_field', ['genre' => 'person']);
 
     $this->assertEquals(
       [


### PR DESCRIPTION
# Overview
Currently the PHPUnit kernel tests for the file ```CitationPluginsTests.php``` PASS but produce the following deprecation notices:
```
Unsilenced deprecation notices (4)

  2x: Creation of dynamic property Drupal\Tests\citation_select\Kernel\CitationPluginTests::$citation_processor is deprecated
    1x in CitationPluginTests::testEntityReference from Drupal\Tests\citation_select\Kernel
    1x in CitationPluginTests::testDefault from Drupal\Tests\citation_select\Kernel

  2x: Creation of dynamic property Drupal\Tests\citation_select\Kernel\CitationPluginTests::$entity_formatter is deprecated
    1x in CitationPluginTests::testEntityReference from Drupal\Tests\citation_select\Kernel
    1x in CitationPluginTests::testDefault from Drupal\Tests\citation_select\Kernel
```
This is caused because the variables ```$citation_processor``` and ```$entity_formatter``` are used but not explicitly defined.

# Changes
- Explicitly defined ```$citation_processor``` variable at the top of the file.
- Changed from using ```$entity_formatter``` to ```$entityReferenceFormatter``` as it is already defined but never used.

# Testing
PHPUnit Tests for the file ```CitationPluginsTests.php``` should PASS and NOT produce the above deprecation notices.