### PR TITLE
fix: add missing module names to the array in tests and update settings schema

### DIFF
--- a/config/schema/citation_select.settings.schema.yml
+++ b/config/schema/citation_select.settings.schema.yml
@@ -4,6 +4,9 @@ citation_select.settings:
   mapping:
     default_style:
       type: string
+    show_on_load:
+      type: boolean
+      label: 'Show Citation by default'
     reference_type_field_map:
       type: ignore
       label: 'Reference Type Field Map'

--- a/tests/src/Functional/CitationFormTests.php
+++ b/tests/src/Functional/CitationFormTests.php
@@ -15,7 +15,7 @@ class CitationFormTests extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected static $modules = [];
+  protected static $modules = ['citation_select'];
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
# Overview
Currently the PHPUnit functional tests for the file ```CitationFormTests.php``` FAIL and produce the following error:
```
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

Testing Drupal\Tests\citation_select\Functional\CitationFormTests
EEEEE                                                               5 / 5 (100%)

Time: 01:11.862, Memory: 14.00 MB

There were 5 errors:

1) Drupal\Tests\citation_select\Functional\CitationFormTests::testCslStyleRoutes
Behat\Mink\Exception\ExpectationException: Current response status code is 404, but 403 expected.

/var/www/drupal/vendor/behat/mink/src/WebAssert.php:888
/var/www/drupal/vendor/behat/mink/src/WebAssert.php:145
/var/www/drupal/web/modules/contrib/citation_select/tests/src/Functional/CitationFormTests.php:68
/var/www/drupal/vendor/phpunit/phpunit/src/Framework/TestResult.php:729

2) Drupal\Tests\citation_select\Functional\CitationFormTests::testSettingsCitationSelectForm
Behat\Mink\Exception\ElementNotFoundException: Form field with id|name|label|value "edit-default-style" not found.

/var/www/drupal/vendor/behat/mink/src/Element/TraversableElement.php:273
/var/www/drupal/web/modules/contrib/citation_select/tests/src/Functional/CitationFormTests.php:113
/var/www/drupal/vendor/phpunit/phpunit/src/Framework/TestResult.php:729

3) Drupal\Tests\citation_select\Functional\CitationFormTests::testStylePage
Behat\Mink\Exception\ExpectationException: Current response status code is 404, but 200 expected.

/var/www/drupal/vendor/behat/mink/src/WebAssert.php:888
/var/www/drupal/vendor/behat/mink/src/WebAssert.php:145
/var/www/drupal/web/modules/contrib/citation_select/tests/src/Functional/CitationFormTests.php:125
/var/www/drupal/vendor/phpunit/phpunit/src/Framework/TestResult.php:729

4) Drupal\Tests\citation_select\Functional\CitationFormTests::testStyleFileForm
Behat\Mink\Exception\ElementNotFoundException: Form field with id|name|label|value|placeholder "edit-label" not found.

/var/www/drupal/vendor/behat/mink/src/Element/TraversableElement.php:165
/var/www/drupal/web/modules/contrib/citation_select/tests/src/Functional/CitationFormTests.php:136
/var/www/drupal/vendor/phpunit/phpunit/src/Framework/TestResult.php:729

5) Drupal\Tests\citation_select\Functional\CitationFormTests::testAddStyleForm
Behat\Mink\Exception\ElementNotFoundException: Form field with id|name|label|value|placeholder "edit-label" not found.

/var/www/drupal/vendor/behat/mink/src/Element/TraversableElement.php:165
/var/www/drupal/web/modules/contrib/citation_select/tests/src/Functional/CitationFormTests.php:150
/var/www/drupal/vendor/phpunit/phpunit/src/Framework/TestResult.php:729

ERRORS!
Tests: 5, Assertions: 31, Errors: 5.
```
This is caused due to some missing schema and because the modules array in test file does not include ```citation_select``` which is essential for testing.

# Changes
- Added missing schema ```show_on_load```.
- Added the module name to the modules array since it is essential for testing.

# Testing
PHPUnit Tests for the file ```CitationFormTests.php``` should PASS.
Note: They might produce a deprecation notice as given below (This will be addressed in another PR as soon as possible).
```
Remaining self deprecation notices (3)

  3x: Passing null to the $typedConfigManager parameter of ConfigFormBase::__construct() is deprecated in drupal:10.2.0 and must be an instance of \Drupal\Core\Config\TypedConfigManagerInterface in drupal:11.0.0. See https://www.drupal.org/node/3404140
    3x in CitationFormTests::testSettingsCitationSelectForm from Drupal\Tests\citation_select\Functional
```