### PR TITLE
fix: change file name suffixes to follow strict Drupal naming conventions

### DIFF
--- a/tests/src/Functional/CitationFormTest.php
+++ b/tests/src/Functional/CitationFormTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\Yaml\Yaml;
  *
  * @group citation_select
  */
-class CitationFormTests extends BrowserTestBase {
+class CitationFormTest extends BrowserTestBase {
 
   /**
    * {@inheritdoc}

--- a/tests/src/Kernel/CitationPluginTest.php
+++ b/tests/src/Kernel/CitationPluginTest.php
@@ -19,7 +19,7 @@ use Drupal\taxonomy\Entity\Vocabulary;
  *
  * @group citation_select
  */
-class CitationPluginTests extends PluginTestBase {
+class CitationPluginTest extends PluginTestBase {
 
   /**
    * Module list.

--- a/tests/src/Kernel/CitationProcessorTest.php
+++ b/tests/src/Kernel/CitationProcessorTest.php
@@ -17,7 +17,7 @@ use Drupal\taxonomy\Entity\Vocabulary;
  *
  * @group citation_select
  */
-class CitationProcessorTests extends KernelTestBase {
+class CitationProcessorTest extends KernelTestBase {
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
# Description
This PR changes all the test cases files suffix names from ***Tests.php** to ***Test.php**, to follow strict Drupal naming conventions. This mistake was pointed out by "baysaa" in [Drupal.org Issue 3555714 Comment](https://www.drupal.org/project/citation_select/issues/3555714#comment-16499837:~:text=Hi%20%40aryan%2Dr,1%20and%202.).

# Credits & Resources
- [Drupal.org Issue 3555714 Comment](https://www.drupal.org/project/citation_select/issues/3555714#comment-16499837:~:text=Hi%20%40aryan%2Dr,1%20and%202.)
- [Suggestion by: baysaa](https://www.drupal.org/u/baysaa)