### PR TITLE
fix: add null check in typed relation formatter

### DIFF
--- a/src/Plugin/CitationFieldFormatter/TypedRelationFormatter.php
+++ b/src/Plugin/CitationFieldFormatter/TypedRelationFormatter.php
@@ -77,7 +77,14 @@ class TypedRelationFormatter extends CitationFieldFormatterBase implements Conta
       $rel_type = $current->get('rel_type')->getString();
       $rel_name = $this->getTypedRelationsMap($node_field)[$rel_type] ?? NULL;
 
-      $entity = $current->get('entity')->getTarget()->getValue();
+      // Check if the entity relationship actually exists before trying to use it.
+      $entity_adapter = $current->get('entity')->getTarget();
+      if (!$entity_adapter || !$entity_adapter->getValue()) {
+        $iterator->next();
+        continue;
+      }
+
+      $entity = $entity_adapter->getValue();
       $value = $entity->getName();
 
       if (!empty($rel_name) && in_array($rel_name, array_keys($csl_fields))) {


### PR DESCRIPTION
# Description
This PR fixes a potential call on null in `TypedRelationFormatter` by adding a check to verify that the entity relationship exists before accessing its value, and skips processing if the entity is missing. 